### PR TITLE
Fix documentation config to run on readthedocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,81 @@
+# travis does not use tox because scipy takes long to install
+# with pip. It is better to use miniconda
 sudo: false
 
 language: python
 
-python: 3.5
-
-env:
-  - TOXENV=py35
-  - TOXENV=py27
-  - TOXENV=docs
-  - TOXENV=flake8
+matrix:
+  fast_finish: true
+  include:
+    - python: 2.7
+      env:
+        - JOB: 'PY27'
+        - FULL_DEPS=true
+    - python: 3.5
+      env:
+        - JOB: 'PY35'
+        - FULL_DEPS=true
+    - python: 3.5
+      env:
+        - JOB: 'DOCS'
+        - FULL_DEPS=true
+    - python: 3.5
+      env:
+        - JOB: 'FLAKE8'
+        - FULL_DEPS=false
 
 cache: pip
 
 notifications:
   email: false
 
+
+# miniconda recipe
+# http://conda.pydata.org/docs/travis.html#using-conda-with-travis-ci
+before_install:
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+
 install:
-   - pip install -U tox
-   - pip install coveralls
+  # Dependencies
+  - conda create -q -n mizani-test python=$TRAVIS_PYTHON_VERSION
+  - source activate mizani-test
+  - if [[ "$FULL_DEPS" ]]; then
+      conda install scipy pandas matplotlib;
+      pip install palettable;
+    fi
+  - if [[ "$JOB" == "PY27" ]] || [[ "$JOB" == "PY35" ]]; then
+      conda install pytest-cov;
+    elif [[ "$JOB" == "DOCS" ]]; then
+      conda install sphinx sphinx_rtd_theme;
+      python setup.py install;
+    elif [[ "$JOB" == "FLAKE8" ]]; then
+      conda install flake8;
+    fi
+  - pip install coveralls
+  # List all conda and pip packages
+  - conda list
 
 script:
-   - tox -e $TOXENV
+  - if [[ "$JOB" == "PY27" ]] || [[ "$JOB" == "PY35" ]]; then
+      coverage erase;
+      py.test mizani/;
+    elif [[ "$JOB" == "DOCS" ]]; then
+      cd doc;
+      sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html;
+    elif [[ "$JOB" == "FLAKE8" ]]; then
+      flake8 --exclude=mizani/external;
+    fi
 
 after_success:
-   - coveralls --rcfile=.coveragerc
+  - coveralls --rcfile=.coveragerc

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -164,7 +164,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,15 +15,28 @@
 import sys
 import os
 
+on_rtd = os.environ.get('READTHEDOCS') == 'True'
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('.'))
 
+if on_rtd:
+    import mock
+    sys.path.insert(0, os.path.abspath('..'))
+    MOCK_MODULES = [
+        'palettable',
+        'pandas',
+        'pandas.core',
+        'pandas.core.common']
+    for mod_name in MOCK_MODULES:
+        sys.modules[mod_name] = mock.Mock()
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.4.2'
+# needs_sphinx = '1.4.2'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -67,11 +80,9 @@ copyright = u'2016, Hassan Kibirige'
 
 try:
     import mizani
+    version = mizani.__version__
 except ImportError:
-    msg = "Error: mizani must be installed before building the documentation"
-    sys.exit(msg)
-
-version = mizani.__version__
+    version = 'unknown'
 
 # The full version, including alpha/beta/rc tags.
 release = version

--- a/mizani/formatters.py
+++ b/mizani/formatters.py
@@ -340,6 +340,7 @@ def timedelta_format(units=None, add_units=True, usetex=False):
         timedelta values and returns a sequence of
         strings.
 
+
     >>> from datetime import timedelta
     >>> x = [timedelta(days=31*i) for i in range(5)]
     >>> timedelta_format()(x)

--- a/mizani/palettes.py
+++ b/mizani/palettes.py
@@ -20,7 +20,7 @@ import colorsys
 import numpy as np
 import matplotlib.colors as mcolors
 from matplotlib.cm import get_cmap
-import palettable.colorbrewer as colorbrewer
+from palettable import colorbrewer
 
 from .external import husl
 from .bounds import rescale

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,5 +10,6 @@ tag_prefix = v
 parentdir_prefix = mizani-
 
 [pytest]
+pyargs = mizani
 doctest_optionflags = ALLOW_UNICODE ALLOW_BYTES NORMALIZE_WHITESPACE
 addopts = --doctest-modules --doctest-ignore-import-errors --cov


### PR DESCRIPTION
Pandas needs to be mocked because the readthedocs version is old
and chocks on `pd.Timedelta`.