### PR TITLE
Explicitly cast log_breaks as float

### DIFF
--- a/mizani/breaks.py
+++ b/mizani/breaks.py
@@ -118,7 +118,7 @@ def log_breaks(n=5, base=10):
             return base ** _min
 
         step = (_max-_min)//n + 1
-        return base ** np.arange(_min, _max+1, step)
+        return base ** np.arange(_min, _max+1, step, dtype=float)
 
     return _log_breaks
 


### PR DESCRIPTION
There seem to recently have been a change to Numpy to be more strict about e.g

`10 ** np.arange(-4, 4)`

This code above produces a `ValueError` in Numpy 1.13.0. Explicitly setting the `dtype` of `np.arange` solves the issue.

This prevents `ValueError: Integers to negative integer powers are not allowed.`