### PR TITLE
Use chain.from_iterable in utils.py

### DIFF
--- a/mizani/utils.py
+++ b/mizani/utils.py
@@ -221,7 +221,7 @@ def multitype_sort(a):
     for t in types:
         types[t] = np.sort(types[t])
 
-    return list(chain(*(types[t] for t in types)))
+    return list(chain.from_iterable(types[t] for t in types))
 
 
 def same_log10_order_of_magnitude(x, delta=0.1):


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.