### PR TITLE
Fix guarding scipy import.

### DIFF
--- a/mizani/transforms.py
+++ b/mizani/transforms.py
@@ -588,10 +588,13 @@ def probability_trans(distribution, *args, **kwargs):
                      doc=doc)
 
 
-logit_trans = probability_trans('logistic', _name='logit',
-                                _doc='Logit Transformation')
-probit_trans = probability_trans('norm', _name='norm',
-                                 _doc='Probit Transformation')
+try:
+    logit_trans = probability_trans('logistic', _name='logit',
+                                    _doc='Logit Transformation')
+    probit_trans = probability_trans('norm', _name='norm',
+                                     _doc='Probit Transformation')
+except ImportError:
+    pass
 
 
 class datetime_trans(trans):


### PR DESCRIPTION
Since probability_trans is called from the top-level of the module,
9885293 still left scipy required. With this it's no longer required.