### PR TITLE
Switch to use of np.power instead of ** for exps

### DIFF
--- a/mizani/transforms.py
+++ b/mizani/transforms.py
@@ -274,10 +274,7 @@ def log_trans(base=None, **kwargs):
 
     # inverse function
     def inverse(x):
-        try:
-            return base ** x
-        except TypeError:
-            return [base**val for val in x]
+        return np.power(base, x)
 
     if 'domain' not in kwargs:
         kwargs['domain'] = (sys.float_info.min, np.inf)
@@ -330,7 +327,7 @@ def exp_trans(base=None, **kwargs):
 
     # transform function
     def transform(x):
-        return base ** x
+        return np.power(base, x)
 
     # inverse function
     def inverse(x):


### PR DESCRIPTION
I was trying to use a "custom" transform in plotnine, 

```Python
from mizani.transforms import exp_trans
exp10 = exp_trans(10)
qplot("carat", "price", data = diamondsk, log="xy") + \
    coord_trans(x=exp10, y = exp10)
```

But this didn't work because it gives the error:

<img width="796" alt="Screen Shot 2021-08-16 at 7 31 18 PM" src="https://user-images.githubusercontent.com/163966/129641806-ff08665a-9dd6-4435-91e3-0abc4418faa9.png">


because plotnine is passing in a tuple of limits but base `**` operator will not "broadcast" correctly and apply the exp on each element in the tuple. I think this should fix this.

I also changed the inverse of log transform to match (I'm guessing that's why the try-catch was necessary there).

