### PR TITLE
Fix numpy.timedelta DeprecationWarning on import

### DIFF
--- a/mizani/_datetime/utils.py
+++ b/mizani/_datetime/utils.py
@@ -29,7 +29,6 @@ EPOCH64 = np.datetime64("1970", "Y")
 SECONDS_PER_DAY = 24 * 60 * 60
 MICROSECONDS_PER_DAY = SECONDS_PER_DAY * (10**6)
 
-NaT_int = np.datetime64("NaT").astype(np.int64)
 MIN_DATETIME64 = np.datetime64("0001-01-01")
 MAX_DATETIME64 = np.datetime64("10000-01-01")
 UTC = ZoneInfo("UTC")
@@ -162,8 +161,7 @@ def datetime64_to_num(x: NDArrayDatetime) -> NDArrayFloat:
         + diff_ns.astype(np.float64) / 1.0e9
     ) / SECONDS_PER_DAY
 
-    x_int = x.astype(np.int64)
-    res[x_int == NaT_int] = np.nan
+    res[np.isnat(x)] = np.nan
     return res
 
 

--- a/tests/datetime/test_utils.py
+++ b/tests/datetime/test_utils.py
@@ -27,6 +27,13 @@ def test_datetime_to_num():
     assert len(datetime_to_num([])) == 0
 
 
+def test_datetime_to_num_handles_nat():
+    result = datetime_to_num(
+        np.array(["2020-01-01", "NaT"], dtype="datetime64[ns]")
+    )
+    assert np.isnan(result[1])
+
+
 def test_num_to_datetime():
     limits = num_to_datetime((25552, 27743))
     assert limits[0] == datetime(2039, 12, 17, tzinfo=ZoneInfo("UTC"))


### PR DESCRIPTION
From `numpy>=2.5.0` [release](https://github.com/numpy/numpy/releases/tag/v2.5.0)  there is a `DeprecationWarning` on the generic `np.datetime64("NaT")` initialisation, which gets called when importing `mizani._datetime.utils`

```
import warnings

warnings.simplefilter("error", DeprecationWarning)

# DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated
import mizani._datetime.utils
```
yields:
```
Traceback (most recent call last):
  File "mizani/repro_script.py", line 6, in <module>
    import mizani._datetime.utils
  File "mizani/mizani/_datetime/utils.py", line 32, in <module>
    NaT_int = np.datetime64("NaT").astype(np.int64)
              ^^^^^^^^^^^^^^^^^^^^
DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.
```

This PR resolves this DeprecationWarning by explicitly checking `np.isnat(x)` rather than comparing equality to `np.datetime64("NaT")`