### PR TITLE
Fix named Brewer palettes selecting the wrong type

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+v0.14.5
+-------
+
+2026-09-04
+
+Bug Fixes
+*********
+
+- :func:`~mizani.palettes.brewer_pal` now resolves a named palette to its own
+  type, so the name no longer has to match the ``type`` argument.
+  ``brewer_pal(palette="Set2")`` now works even though ``type`` defaults to
+  sequential and ``Set2`` is qualitative. An unknown name raises a
+  ``ValueError`` listing the valid names. This resolves `(plotnine #1048)
+  <https://github.com/has2k1/plotnine/issues/1048>`_.
+
+
 v0.14.4
 -------
 

--- a/mizani/_colors/_palettes/brewer/__init__.py
+++ b/mizani/_colors/_palettes/brewer/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cache
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -36,7 +37,42 @@ def get_palette_module(scheme: ColorScheme | ColorSchemeShort) -> ModuleType:
 
         return diverging
     else:
-        raise ValueError(f"Unknown type of brewer palette: {type}")
+        raise ValueError(f"Unknown type of brewer palette: {scheme}")
+
+
+@cache
+def _palette_schemes() -> dict[str, ColorScheme]:
+    """
+    Return every brewer palette's scheme, keyed by palette name
+
+    Palette names are unique across schemes, so each name identifies one
+    scheme.
+    """
+    schemes: tuple[ColorScheme, ...] = (
+        "sequential",
+        "qualitative",
+        "diverging",
+    )
+    return {
+        name: scheme
+        for scheme in schemes
+        for name in get_palette_names(scheme)
+    }
+
+
+def get_palette_scheme(name: str) -> ColorScheme:
+    """
+    Return the scheme for a named palette
+
+    Raise a `ValueError` if the name is not a brewer palette.
+    """
+    lookup = _palette_schemes()
+    if name not in lookup:
+        raise ValueError(
+            f"Unknown brewer palette: '{name}'. The valid names are "
+            f"{sorted(lookup)}."
+        )
+    return lookup[name]
 
 
 def number_to_name(scheme: ColorScheme | ColorSchemeShort, n: int) -> str:
@@ -49,7 +85,7 @@ def number_to_name(scheme: ColorScheme | ColorSchemeShort, n: int) -> str:
     names = mod.__all__
     if n > len(names):
         raise ValueError(
-            f"There are only '{n}' palettes of type {scheme}. "
+            f"There are only '{len(names)}' palettes of type {scheme}. "
             f"You requested palette no. {n}"
         )
     return names[n - 1]
@@ -60,8 +96,13 @@ def get_brewer_palette(
 ) -> ColorPalette:
     """
     Return color palette from a given scheme
+
+    The scheme selects a palette given by number. A palette given by name
+    belongs to one scheme only, so the name overrides `scheme`.
     """
     if isinstance(palette, int):
         palette = number_to_name(scheme, palette)
+    else:
+        scheme = get_palette_scheme(palette)
     mod = get_palette_module(scheme)
     return getattr(mod, palette)

--- a/mizani/palettes.py
+++ b/mizani/palettes.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import colorsys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 from warnings import warn
 
 import numpy as np
@@ -477,15 +477,14 @@ class brewer_pal(_discrete_pal):
     Parameters
     ----------
     type : 'sequential' | 'qualitative' | 'diverging'
-        Type of palette. Sequential, Qualitative or
-        Diverging. The following abbreviations may
-        be used, ``seq``, ``qual`` or ``div``.
+        Type from which to choose a numeric `palette`. The abbreviations
+        `seq`, `qual`, and `div` are supported. A named palette selects its
+        own type, and `type` becomes its long form, such as `'qualitative'`.
     palette : int | str
-        Which palette to choose from. If is an integer,
-        it must be in the range ``[0, m]``, where ``m``
-        depends on the number sequential, qualitative or
-        diverging palettes. If it is a string, then it
-        is the name of the palette.
+        Palette to choose. An integer must be in the range `[0, m]`, where
+        `m` depends on the number of sequential, qualitative, or diverging
+        palettes. A string must be a palette name; an unknown name raises a
+        `ValueError`.
     direction : int
         The order of colours in the scale. If -1 the order
         of colors is reversed. The default is 1.
@@ -509,10 +508,18 @@ class brewer_pal(_discrete_pal):
     >>> brewer_pal('seq', 'PuBuGn')(5)
     ['#F6EFF7', '#BDC9E1', '#67A9CF', '#1C9099', '#016C59']
 
+    A named palette does not need a matching `type`.
+
+    >>> pal = brewer_pal(palette='Set2')
+    >>> pal(3)
+    ['#66C2A5', '#FC8D62', '#8DA0CB']
+    >>> pal.type
+    'qualitative'
+
     The available color names for each palette type can be
     obtained using the following code::
 
-        from mizani._colors.brewer import get_palette_names
+        from mizani._colors._palettes.brewer import get_palette_names
 
         print(get_palette_names("sequential"))
         print(get_palette_names("qualitative"))
@@ -530,6 +537,7 @@ class brewer_pal(_discrete_pal):
             raise ValueError("direction should be 1 or -1.")
 
         self.bpal = get_brewer_palette(self.type, self.palette)
+        self.type = cast("ColorScheme", self.bpal.kind.value)
 
     def __call__(self, n: int) -> Sequence[RGBHexColor | None]:
         # Only draw the maximum allowable colors from the palette

--- a/tests/test_palettes.py
+++ b/tests/test_palettes.py
@@ -135,6 +135,28 @@ def test_brewer_pal():
         brewer_pal(direction=-2)(100)
 
 
+def test_brewer_pal_named_palette_selects_its_type():
+    # A unique name identifies the palette type and overrides the default or
+    # explicitly supplied type.
+    result = brewer_pal(palette="Set2")(3)
+    assert all(s[0] == "#" and len(s) == 7 for s in result)
+
+    result = brewer_pal("div", "Blues")(3)
+    assert all(s[0] == "#" and len(s) == 7 for s in result)
+
+    assert brewer_pal(palette="Set2").type == "qualitative"
+    assert brewer_pal("div", "Blues").type == "sequential"
+
+    with pytest.raises(ValueError, match="Nonesuch"):
+        brewer_pal(palette="Nonesuch")
+
+
+def test_brewer_pal_number_out_of_range():
+    # Report the number of available palettes, not the requested number.
+    with pytest.raises(ValueError, match="only '8' palettes of type qual"):
+        brewer_pal("qual", 20)
+
+
 def test_brewer_palette_names():
     from mizani._colors._palettes.brewer import get_palette_names
 


### PR DESCRIPTION
This PR makes named Brewer palettes select their own type, so calls such as brewer_pal(palette="Set2") work without a matching type argument.

It also adds clear errors for unknown palette names, corrects the out-of-range palette message, and adds regression tests and changelog documentation.


resolves has2k1/plotnine#1048