### PR TITLE
ENH: Accept a per-end only_inside in breaks_extended

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+v0.14.6
+-------
+
+Enhancements
+************
+
+- :class:`~mizani.breaks.breaks_extended` accepts a pair for
+  ``only_inside``, one flag per end, so a break sequence can be held
+  inside the limits at one end and allowed past them at the other.
+
+
 v0.14.5
 -------
 

--- a/mizani/breaks.py
+++ b/mizani/breaks.py
@@ -655,9 +655,14 @@ class breaks_extended:
         Desired number of breaks
     Q : list
         List of nice numbers
-    only_inside : bool
+    only_inside : bool | tuple[bool, bool]
         If ``True``, then all the breaks will be within the given
-        range.
+        range. A pair ``(lower, upper)`` constrains each end on its
+        own, so ``(True, False)`` keeps the first break at or above
+        the lower limit while the last break may lie beyond the
+        upper limit. The coverage score treats the two ends
+        separately (Talbot et al., 2010), so the search is unchanged;
+        only the candidates it admits are.
     w : list
         Weights applied to the four optimization components
         (simplicity, coverage, density, and legibility). They
@@ -670,6 +675,8 @@ class breaks_extended:
     array([  0. ,   2.5,   5. ,   7.5,  10. ])
     >>> breaks_extended(n=6)(limits)
     array([  0.,   2.,   4.,   6.,   8.,  10.])
+    >>> breaks_extended(n=3, only_inside=(True, False))((-7.7, 196.9))
+    array([  0., 100., 200.])
 
     References
     ----------
@@ -683,12 +690,16 @@ class breaks_extended:
 
     n: int = 5
     Q: Sequence[float] = (1, 5, 2, 2.5, 4, 3)
-    only_inside: bool = False
+    only_inside: bool | tuple[bool, bool] = False
     w: Sequence[float] = (0.25, 0.2, 0.5, 0.05)
 
     def __post_init__(self):
         # Used for lookups during the computations
         self.Q_index = {q: i for i, q in enumerate(self.Q)}
+        if isinstance(self.only_inside, bool):
+            self._inside = (self.only_inside, self.only_inside)
+        else:
+            self._inside = tuple(self.only_inside)
 
     def coverage(
         self, dmin: float, dmax: float, lmin: float, lmax: float
@@ -764,7 +775,7 @@ class breaks_extended:
         """
         Q = self.Q
         w = self.w
-        only_inside = self.only_inside
+        inside_lower, inside_upper = self._inside
         simplicity_max = self.simplicity_max
         density_max = self.density_max
         coverage_max = self.coverage_max
@@ -835,9 +846,10 @@ class breaks_extended:
 
                             score = w[0] * s + w[1] * c + w[2] * d + w[3] * l
 
-                            if score > best_score and (
-                                not only_inside
-                                or (lmin >= dmin and lmax <= dmax)
+                            if (
+                                score > best_score
+                                and (not inside_lower or lmin >= dmin)
+                                and (not inside_upper or lmax <= dmax)
                             ):
                                 best_score = score
                                 best = (lmin, lmax, lstep, q, k)

--- a/tests/test_breaks.py
+++ b/tests/test_breaks.py
@@ -438,3 +438,32 @@ def test_breaks_extended():
     limits = [np.pi, np.pi]
     assert len(breaks(limits)) == 1
     assert breaks(limits)[0] == limits[1]
+
+
+def test_breaks_extended_only_inside_per_end():
+    limits = (-7.7, 196.9)
+
+    # A pair of equal flags is the same as the single flag
+    for flag in (True, False):
+        npt.assert_array_equal(
+            breaks_extended(n=3, only_inside=(flag, flag))(limits),
+            breaks_extended(n=3, only_inside=flag)(limits),
+        )
+
+    # Each end honours its own flag: the constrained end stays inside,
+    # the free end may go past its limit
+    breaks = breaks_extended(n=3, only_inside=(True, False))(limits)
+    npt.assert_array_equal(breaks, [0, 100, 200])
+    breaks = breaks_extended(n=3, only_inside=(False, True))((3.1, 207.7))
+    npt.assert_array_equal(breaks, [0, 100, 200])
+
+    # Over many ranges the constrained end never crosses its limit
+    rng = np.random.default_rng(0)
+    for _ in range(200):
+        lo = rng.uniform(-50, 50)
+        hi = lo + 10 ** rng.uniform(-1, 3)
+        n = int(rng.integers(2, 9))
+        breaks = breaks_extended(n=n, only_inside=(True, False))((lo, hi))
+        assert breaks[0] >= lo
+        breaks = breaks_extended(n=n, only_inside=(False, True))((lo, hi))
+        assert breaks[-1] <= hi


### PR DESCRIPTION
`only_inside` now also takes a pair `(lower, upper)`, one flag per end, so a break sequence can be held inside the limits at one end and allowed past them at the other. A single bool keeps its meaning for both ends, so nothing changes for existing callers.

The search itself is untouched. Talbot's coverage score is already a sum of one term per end, so the ends are scored independently; the flag only decides which candidates the search admits, and the per-end flag splits that check the same way. One example of the effect, at `n=3` on limits `(-7.7, 196.9)`: `only_inside=True` gives `[0, 90, 180]`, and `only_inside=(True, False)` gives `[0, 100, 200]`, because a labeling that ends past the data may now compete.

Motivation: a range frame that ends at a round number on one side and at the data on the other, for which the inside-only search picks a step that fits inside and then has to be padded, while the free-on-one-side search picks the step for the labeling that is actually drawn.

Adds a test for the pair, including the equivalence of `(flag, flag)` with `flag`, and a changelog entry under an unreleased v0.14.6 heading, which you may want to rename.
